### PR TITLE
feat: add themed footer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -397,6 +397,15 @@
     backdrop-filter: saturate(1.2) blur(2px);
   }
 
+  .retro-footer {
+    height: 24px;
+    background: linear-gradient(to top,
+        color-mix(in oklab, var(--color-card), white 12%),
+        color-mix(in oklab, var(--color-card), black 4%));
+    border-top: 1px solid var(--color-border);
+    backdrop-filter: saturate(1.2) blur(2px);
+  }
+
   @keyframes retro-pop {
     0% {
       opacity: 0;
@@ -513,5 +522,15 @@
   .theme-xp .retro-control.green {
     background: #45c742;
     border-color: #2d9f2a;
+  }
+
+  .theme-xp .retro-footer {
+    background: linear-gradient(to top, #3b6cd0, #1d52b5);
+    border-top-color: #0c2f6a;
+    color: #ffffff;
+  }
+
+  .theme-xp .retro-footer a {
+    color: #ffffff;
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { FileUploadZone } from "@/components/file-upload-zone"
 import { ProcessingStatus } from "@/components/processing-status"
 import { DatabaseViewer } from "@/components/database-viewer"
 import { Header } from "@/components/header"
+import Footer from "@/components/footer"
 import { usePyodide } from "@/hooks/use-pyodide"
 import { Badge } from "@/components/ui/badge"
 import {
@@ -100,7 +101,7 @@ export default function IFCDataBrowser() {
   }
 
   return (
-    <div className="min-h-screen retro-desktop">
+    <div className="min-h-screen retro-desktop flex flex-col">
       <Header
         showOsToggle={currentView === "upload"}
         usePyodide={usePyodideHook}
@@ -108,7 +109,7 @@ export default function IFCDataBrowser() {
         hasProcessedData={!!databaseData}
       />
 
-      <main className="min-h-screen">
+      <main className="flex-1">
         {currentView === "upload" && (
           <>
             {/* Retro Hero Window */}
@@ -406,6 +407,7 @@ export default function IFCDataBrowser() {
           <DatabaseViewer data={databaseData} onBackToUpload={handleBackToUpload} fileName={uploadedFile?.name} usePyodide={usePyodideHook} />
         )}
       </main>
+      <Footer />
     </div>
   )
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect, useState } from "react"
+
+export default function Footer() {
+  const [isXp, setIsXp] = useState(false)
+
+  useEffect(() => {
+    const handler = () => {
+      if (typeof document !== "undefined") {
+        setIsXp(document.documentElement.classList.contains("theme-xp"))
+      }
+    }
+    handler()
+    const observer = new MutationObserver(handler)
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] })
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <footer className="retro-footer text-xs flex items-center justify-center gap-4 px-3">
+      <Link
+        href="https://www.lt.plus"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1 hover:underline"
+      >
+        {isXp ? "🌐" : "🍎"}
+        www.lt.plus
+      </Link>
+      <span className="opacity-40">|</span>
+      <Link
+        href="https://github.com/louistrue/ifc-data-browser"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1 hover:underline"
+      >
+        {isXp ? "🪟" : "<>"}
+        GitHub
+      </Link>
+      <span className="opacity-40">|</span>
+      <span className="flex items-center gap-1">
+        Made with <span className="animate-pulse">❤️</span> by Louis Trümpler
+      </span>
+    </footer>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add responsive footer with mac and xp styles
- include links to lt.plus and GitHub, plus author credit

## Testing
- `pnpm lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ecfd837c8320bc00dbc8813f055f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a retro-themed footer with theme-aware icons and links to the website and GitHub, plus a creator credit message.

* **Style**
  * Introduced default footer styling with gradient background, top border, and backdrop filter.
  * Added an XP theme variant with blue gradient and white text, ensuring clear link visibility.

* **Refactor**
  * Updated page layout to a vertical flex structure, allowing the main content to flex and preventing overlap with the footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->