### PR TITLE
Add themed footer with project links

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -397,6 +397,37 @@
     backdrop-filter: saturate(1.2) blur(2px);
   }
 
+  .retro-footer {
+    height: 26px;
+    background: linear-gradient(to top,
+        color-mix(in oklab, var(--color-card), white 12%),
+        color-mix(in oklab, var(--color-card), black 4%));
+    border-top: 1px solid var(--color-border);
+    backdrop-filter: saturate(1.2) blur(2px);
+  }
+
+  .theme-xp .retro-footer {
+    background: linear-gradient(to top, #1e90ff, #1454c2);
+    border-top-color: #0d3a91;
+    color: #ffffff;
+  }
+
+  .retro-footer .mac-icon {
+    display: inline;
+  }
+
+  .retro-footer .xp-icon {
+    display: none;
+  }
+
+  .theme-xp .retro-footer .mac-icon {
+    display: none;
+  }
+
+  .theme-xp .retro-footer .xp-icon {
+    display: inline;
+  }
+
   @keyframes retro-pop {
     0% {
       opacity: 0;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { FileUploadZone } from "@/components/file-upload-zone"
 import { ProcessingStatus } from "@/components/processing-status"
 import { DatabaseViewer } from "@/components/database-viewer"
 import { Header } from "@/components/header"
+import { Footer } from "@/components/footer"
 import { usePyodide } from "@/hooks/use-pyodide"
 import { Badge } from "@/components/ui/badge"
 import {
@@ -100,7 +101,7 @@ export default function IFCDataBrowser() {
   }
 
   return (
-    <div className="min-h-screen retro-desktop">
+    <div className="min-h-screen flex flex-col retro-desktop">
       <Header
         showOsToggle={currentView === "upload"}
         usePyodide={usePyodideHook}
@@ -108,7 +109,7 @@ export default function IFCDataBrowser() {
         hasProcessedData={!!databaseData}
       />
 
-      <main className="min-h-screen">
+      <main className="flex-1">
         {currentView === "upload" && (
           <>
             {/* Retro Hero Window */}
@@ -406,6 +407,7 @@ export default function IFCDataBrowser() {
           <DatabaseViewer data={databaseData} onBackToUpload={handleBackToUpload} fileName={uploadedFile?.name} usePyodide={usePyodideHook} />
         )}
       </main>
+      <Footer />
     </div>
   )
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+
+export function Footer() {
+  return (
+    <footer className="retro-footer text-[11px]">
+      <div className="container mx-auto h-full flex items-center justify-center sm:justify-between px-3 gap-2">
+        <div className="flex items-center gap-1">
+          <span className="mac-icon">🍏</span>
+          <span className="xp-icon">🪟</span>
+          <a
+            href="https://www.lt.plus"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            www.lt.plus
+          </a>
+        </div>
+        <div className="hidden sm:block text-center">
+          Made with <span className="text-red-500">❤️</span> by Louis Trümpler
+        </div>
+        <div>
+          <a
+            href="https://github.com/louistrue/ifc-data-browser"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            GitHub repo
+          </a>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+export default Footer


### PR DESCRIPTION
## Summary
- add creative footer with links to lt.plus, GitHub repo, and attribution
- style footer differently for mac and windows themes
- integrate footer into main layout

## Testing
- `pnpm lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ecfd837c8320bc00dbc8813f055f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent retro footer across pages with platform icons, a creator message, and links (site and GitHub) opening in new tabs.

* **Style**
  * Introduced themed footer styling with a gradient background, top border, and backdrop blur.
  * Added XP theme variant with blue gradient and white text.
  * Icon visibility adapts per theme (Mac vs. XP).

* **Refactor**
  * Updated layout to a vertical flex structure, ensuring the footer stays pinned at the bottom and main content expands to fill space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->