### PR TITLE
Ensure tabs fill full width on larger screens

### DIFF
--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-full items-center justify-start rounded-lg p-[3px] overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:w-fit sm:justify-center",
+        "bg-muted text-muted-foreground inline-flex h-9 w-full items-center justify-start rounded-lg p-[3px] overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:overflow-visible sm:justify-center",
         className
       )}
       {...props}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-full items-center justify-start rounded-lg p-[3px] overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:overflow-visible sm:justify-center",
+        "bg-muted text-muted-foreground inline-flex h-9 w-full items-center justify-start rounded-lg p-[3px] overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Keep tab lists full-width on larger screens while preserving horizontal scroll on mobile

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ac4a4f88508320bcf58945061ee83f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tabs list no longer clips or hides tab items on small screens; overflowing labels are now visible.

* **Style**
  * Adjusted small-screen layout of the tabs list to keep full-width, left-aligned behavior and allow visible overflow, improving readability when tab labels exceed available space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->